### PR TITLE
discover nested vsconfigs

### DIFF
--- a/VSConfigFinder.Test/.editorconfig
+++ b/VSConfigFinder.Test/.editorconfig
@@ -118,6 +118,8 @@ dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
 
 # Diagnostics
 
+# CS8602: Dereference of a possibly null reference.
+dotnet_diagnostic.CS8602.severity = error
 # CS8603: Possible null reference return.
 dotnet_diagnostic.CS8603.severity = error
 dotnet_style_namespace_match_folder = true:suggestion

--- a/VSConfigFinder.Test/UtilitiesTests.cs
+++ b/VSConfigFinder.Test/UtilitiesTests.cs
@@ -5,6 +5,9 @@
 
 namespace VSConfigFinder.Test
 {
+    using Moq;
+    using System.Text;
+    using System.Text.Json;
     using Xunit;
 
     public class UtilitiesTests
@@ -24,6 +27,98 @@ namespace VSConfigFinder.Test
         {
             var str = "some string";
             Utilities.ValidateIsNotNullOrEmpty(str, nameof(str));
+        }
+
+        [Fact]
+        public void CreateOutput_Creates_File_With_Expected_String()
+        {
+            var fileSystem = new Mock<IFileSystem>();
+            var finalConfig = new VSConfig
+            {
+                Version = new Version("1.0"),
+                Components = new[]
+                {
+                    "Microsoft.VisualStudio.Component.NuGet",
+                    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+                    "Microsoft.Component.MSBuild",
+                    "Microsoft.NetCore.Component.Runtime.6.0"
+                },
+            };
+
+            var jsonString = """
+                {
+                  "Version": "1.0",
+                  "Components": [
+                    "Microsoft.VisualStudio.Component.NuGet",
+                    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+                    "Microsoft.Component.MSBuild",
+                    "Microsoft.NetCore.Component.Runtime.6.0"
+                  ]
+                }
+                """;
+
+            var options = new CommandLineOptions
+            {
+                FolderPath = "C:\\input",
+                CreateFile = true,
+                ConfigOutputPath = "C:\\output",
+            };
+
+            Utilities.CreateOutput(fileSystem.Object, finalConfig, options);
+
+            var outputPath = Path.Combine(options.ConfigOutputPath, ".vsconfig");
+            fileSystem.Verify(x => x.WriteAllText(outputPath, jsonString));
+        }
+
+        [Fact]
+        public void ReadComponents_Reads_AllNestedDirectories_And_OutputsAllComponents()
+        {
+            var fileSystem = new Mock<IFileSystem>();
+
+            var options = new CommandLineOptions
+            {
+                FolderPath = "C:\\input",
+                ConfigOutputPath = "C:\\output",
+            };
+
+            // pathA
+            var pathA = "C:\\pathA";
+            var pathAConfig = """
+                {
+                  "Version": "1.0",
+                  "Components": [
+                    "Microsoft.VisualStudio.Component.NuGet",
+                    "Microsoft.Component.MSBuild",
+                  ]
+                }
+                """;
+            var pathAReader = new MemoryStream(Encoding.UTF8.GetBytes(pathAConfig));
+
+            // pathB
+            var pathB = "C:\\pathB";
+            var pathBConfig = """
+                {
+                  "Version": "1.0",
+                  "Components": [
+                    "Microsoft.VisualStudio.Component.NuGet",
+                    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+                  ]
+                }
+                """;
+            var pathBReader = new MemoryStream(Encoding.UTF8.GetBytes(pathBConfig));
+
+            fileSystem.Setup(x => x.GetFileSystemEntries(options.FolderPath, ".vsconfig", true)).Returns(new[] { pathA, pathB });
+
+            fileSystem.Setup(x => x.OpenFile(pathA)).Returns(pathAReader);
+            fileSystem.Setup(x => x.OpenFile(pathB)).Returns(pathBReader);
+
+            var components = Utilities.ReadComponents(fileSystem.Object, options);
+            Assert.Equal(3, components.Length);
+            Assert.Collection(
+                components,
+                x => Assert.Equal("Microsoft.VisualStudio.Component.NuGet", x),
+                x => Assert.Equal("Microsoft.Component.MSBuild", x),
+                x => Assert.Equal("Microsoft.VisualStudio.Component.Roslyn.Compiler", x));
         }
     }
 }

--- a/VSConfigFinder.Test/VSConfigFinder.Test.csproj
+++ b/VSConfigFinder.Test/VSConfigFinder.Test.csproj
@@ -10,6 +10,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VSConfigFinder/.editorconfig
+++ b/VSConfigFinder/.editorconfig
@@ -1,4 +1,4 @@
-file_header_template = <copyright file="{fileName}" company="Microsoft Corporation">\nCopyright (C) Microsoft Corporation. All rights reserved.\nLicensed under the MIT license. See LICENSE.txt in the project root for license information.\n</copyright>
+﻿file_header_template = <copyright file="{fileName}" company="Microsoft Corporation">\nCopyright (C) Microsoft Corporation. All rights reserved.\nLicensed under the MIT license. See LICENSE.txt in the project root for license information.\n</copyright>
 
 # All files
 [*]
@@ -118,6 +118,8 @@ dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
 
 # Diagnostics
 
+# CS8602: Dereference of a possibly null reference.
+dotnet_diagnostic.CS8602.severity = error
 # CS8603: Possible null reference return.
 dotnet_diagnostic.CS8603.severity = error
 dotnet_style_namespace_match_folder = true:suggestion

--- a/VSConfigFinder/CommandLine/VSConfig.cs
+++ b/VSConfigFinder/CommandLine/VSConfig.cs
@@ -10,7 +10,7 @@ namespace VSConfigFinder
     /// <summary>
     /// The class object that defines a .vsconfig file.
     /// </summary>
-    internal class VSConfig
+    public class VSConfig
     {
         /// <summary>
         /// Gets or sets the version of the .vsconfig file.

--- a/VSConfigFinder/FileSystem.cs
+++ b/VSConfigFinder/FileSystem.cs
@@ -1,0 +1,28 @@
+﻿namespace VSConfigFinder
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+    using System.Diagnostics.CodeAnalysis;
+    using System.IO;
+    using System.Text.Json;
+
+    public class FileSystem : IFileSystem
+    {
+        /// <inheritdoc/>
+        public string[] GetFileSystemEntries(string path, string pattern, bool recursive = false)
+        {
+            Utilities.ValidateIsNotNullOrEmpty(path, nameof(path));
+            Utilities.ValidateIsNotNullOrEmpty(pattern, nameof(pattern));
+
+            return Directory.GetFileSystemEntries(path, pattern, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+        }
+
+        /// <inheritdoc/>
+        public Stream OpenFile(string path)
+        {
+            Utilities.ValidateIsNotNullOrEmpty(path, nameof(Path));
+
+            return File.OpenRead(path);
+        }
+    }
+}

--- a/VSConfigFinder/FileSystem.cs
+++ b/VSConfigFinder/FileSystem.cs
@@ -1,11 +1,13 @@
-﻿namespace VSConfigFinder
-{
-    using System;
-    using System.ComponentModel.DataAnnotations;
-    using System.Diagnostics.CodeAnalysis;
-    using System.IO;
-    using System.Text.Json;
+﻿// <copyright file="FileSystem.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
 
+namespace VSConfigFinder
+{
+    using System.IO;
+
+    /// <inheritdoc/>
     public class FileSystem : IFileSystem
     {
         /// <inheritdoc/>
@@ -23,6 +25,14 @@
             Utilities.ValidateIsNotNullOrEmpty(path, nameof(Path));
 
             return File.OpenRead(path);
+        }
+
+        /// <inheritdoc/>
+        public void WriteAllText(string path, string data)
+        {
+            Utilities.ValidateIsNotNullOrEmpty(path, nameof(Path));
+
+            File.WriteAllText(path, data);
         }
     }
 }

--- a/VSConfigFinder/IFileSystem.cs
+++ b/VSConfigFinder/IFileSystem.cs
@@ -1,0 +1,10 @@
+﻿namespace VSConfigFinder
+{
+
+    public interface IFileSystem
+    {
+        public string[] GetFileSystemEntries(string path, string pattern, bool recursive = false);
+
+        public Stream OpenFile(string path);
+    }
+}

--- a/VSConfigFinder/IFileSystem.cs
+++ b/VSConfigFinder/IFileSystem.cs
@@ -1,10 +1,42 @@
-﻿namespace VSConfigFinder
-{
+﻿// <copyright file="IFileSystem.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
 
+namespace VSConfigFinder
+{
+    /// <summary>
+    /// The interface for the <see cref="FileSystem"/>.
+    /// </summary>
     public interface IFileSystem
     {
+        /// <summary>
+        /// Get files and directories within directory.
+        /// </summary>
+        /// <param name="path">directory path</param>
+        /// <param name="pattern">pattern to match for file names. To match anything and everything, specify '*'</param>
+        /// <param name="recursive">Optional: recursively search sub directories</param>
+        /// <returns>array of files within the directory</returns>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
         public string[] GetFileSystemEntries(string path, string pattern, bool recursive = false);
 
+        /// <summary>
+        /// Opens a file for reading.
+        /// </summary>
+        /// <param name="path">The path to a file to open.</param>
+        /// <returns>A stream of the opened file.</returns>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
         public Stream OpenFile(string path);
+
+        /// <summary>
+        /// Writes all text in a path.
+        /// </summary>
+        /// <param name="path">The path to a file to write.</param>
+        /// <param name="data">The string data to write.</param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
+        public void WriteAllText(string path, string data);
     }
 }

--- a/VSConfigFinder/Program.cs
+++ b/VSConfigFinder/Program.cs
@@ -7,6 +7,7 @@ namespace VSConfigFinder
 {
     using CommandLine;
     using System.IO;
+    using System.Text.Json;
 
     /// <summary>
     /// <see cref="Program"/> class for the .vsconfig finder tool.
@@ -23,7 +24,7 @@ namespace VSConfigFinder
             {
                 with.CaseSensitive = false;
             });
-
+            
             // Take in the command line arguments
             parser.ParseArguments<CommandLineOptions>(args)
                 .WithParsed(Run)
@@ -32,19 +33,27 @@ namespace VSConfigFinder
 
         private static void Run(CommandLineOptions options)
         {
-            Console.WriteLine("Hello! I succeeded!");
-            Console.WriteLine($"--createFile: {options.CreateFile}");
-            Console.WriteLine($"--configOutputPath: {options.ConfigOutputPath}");
-
+            // Run
             if (options.CreateFile)
             {
                 options.ConfigOutputPath ??= Directory.GetCurrentDirectory();
             }
+
+            string[] allComponents = Utilities.ReadComponents(options); 
+
+            var finalConfig = new VSConfig()
+            {
+                Version = new Version("1.0"),
+                Components = allComponents,
+            };
+
+            // Output
+            Utilities.CreateOutput(finalConfig, options);
         }
 
         private static void HandleParseError(IEnumerable<Error> errors)
         {
-            Console.WriteLine("Oops, failed");
+            Console.WriteLine("Please make sure that you have provided the correct arguments. Try --help to see all the available arguments and explanations.");
         }
     }
 }

--- a/VSConfigFinder/Program.cs
+++ b/VSConfigFinder/Program.cs
@@ -7,7 +7,6 @@ namespace VSConfigFinder
 {
     using CommandLine;
     using System.IO;
-    using System.Text.Json;
 
     /// <summary>
     /// <see cref="Program"/> class for the .vsconfig finder tool.
@@ -25,7 +24,6 @@ namespace VSConfigFinder
                 with.CaseSensitive = false;
             });
             
-            // Take in the command line arguments
             parser.ParseArguments<CommandLineOptions>(args)
                 .WithParsed(Run)
                 .WithNotParsed(HandleParseError);
@@ -33,22 +31,26 @@ namespace VSConfigFinder
 
         private static void Run(CommandLineOptions options)
         {
-            // Run
+            var fileSystem = new FileSystem();
+
+            ResolveCommandLineOptions(options);
+
+            var finalConfig = new VSConfig()
+            {
+                // This is the new final .vsconfig, so version 1.0 is used.
+                Version = new Version("1.0"),
+                Components = Utilities.ReadComponents(fileSystem, options),
+            };
+
+            Utilities.CreateOutput(fileSystem, finalConfig, options);
+        }
+
+        private static void ResolveCommandLineOptions(CommandLineOptions options)
+        {
             if (options.CreateFile)
             {
                 options.ConfigOutputPath ??= Directory.GetCurrentDirectory();
             }
-
-            string[] allComponents = Utilities.ReadComponents(options); 
-
-            var finalConfig = new VSConfig()
-            {
-                Version = new Version("1.0"),
-                Components = allComponents,
-            };
-
-            // Output
-            Utilities.CreateOutput(finalConfig, options);
         }
 
         private static void HandleParseError(IEnumerable<Error> errors)

--- a/VSConfigFinder/Utilities.cs
+++ b/VSConfigFinder/Utilities.cs
@@ -6,20 +6,13 @@
 namespace VSConfigFinder
 {
     using System.Diagnostics.CodeAnalysis;
+    using System.Text;
+    using System.Text.Json;
 
-    internal class Utilities
+    public class Utilities
     {
-        private static readonly string[] AcceptedOutputOptions = new[] { "config", "commandline" };
-
-        public static void ValidateOutputParameter([NotNull] string s, string paramName)
-        {
-            ValidateIsNotNullOrEmpty(s, paramName);
-
-            if (!AcceptedOutputOptions.Contains(s))
-            {
-                throw new ArgumentException($"The --output parameter accepts only two options: {string.Join(",", AcceptedOutputOptions)}.");
-            }
-        }
+        private static readonly string ConfigExtension = ".vsconfig";
+        private static readonly string Add = "--add";
 
         public static void ValidateIsNotNullOrEmpty([NotNull] string s, string paramName)
         {
@@ -41,6 +34,65 @@ namespace VSConfigFinder
             {
                 throw new ArgumentException("The string is empty.", paramName);
             }
+        }
+
+        public static void CreateOutput(VSConfig finalConfig, CommandLineOptions options)
+        {
+            if (options.CreateFile)
+            {
+                // Create a file
+                var serializerOptions = new JsonSerializerOptions { WriteIndented = true };
+                var jsonString = JsonSerializer.Serialize(finalConfig, serializerOptions);
+                var outputPath = Path.Combine(options.ConfigOutputPath!, ConfigExtension);
+
+                File.WriteAllText(outputPath, jsonString);
+                Console.WriteLine($"Successfully created the final .vsconfig at {outputPath}");
+            }
+            else
+            {
+                // output to a command line
+                var output = CreateCommandLineOutput(finalConfig);
+                Console.WriteLine(output);
+            }
+        }
+
+        private static string CreateCommandLineOutput(VSConfig finalConfig)
+        {
+            var output = new StringBuilder(Add + " ");
+
+            foreach (var component in finalConfig.Components)
+            {
+                if (!string.IsNullOrEmpty(component))
+                {
+                    output.AppendFormat("{0} ", component);
+                }
+            }
+
+            return output.ToString();
+        }
+
+        public static string[] ReadComponents(CommandLineOptions options)
+        {
+            var fileSystem = new FileSystem();
+            var pathsToVsConfigs = fileSystem.GetFileSystemEntries(options.FolderPath, ConfigExtension, true);
+
+            HashSet<string> componentsSet = new HashSet<string>();
+            var serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+            foreach (var path in pathsToVsConfigs)
+            {
+                var stream = fileSystem.OpenFile(path);
+                var components = JsonSerializer.Deserialize<VSConfig>(stream, serializerOptions).Components;
+
+                if (components != null)
+                {
+                    componentsSet.UnionWith(components);
+                }
+
+                stream.Close();
+            };
+
+            return componentsSet.ToArray();
         }
     }
 }


### PR DESCRIPTION
Discover nested vsconfigs and collect components to create final vsconfig

- [x] Manually tested discovering directories where .vsconfig exists and collecting components (unique)
<img width="437" alt="paths" src="https://user-images.githubusercontent.com/38011929/218823175-bafd7f07-cb65-4533-9456-b412ffa014c7.png">
<img width="315" alt="components" src="https://user-images.githubusercontent.com/38011929/218823189-1c168594-7d04-4e90-9fd6-10ed0cb7ed5e.png">
<img width="284" alt="finalvsconfig" src="https://user-images.githubusercontent.com/38011929/218823206-2c6f25ae-fac0-4083-baf5-a40bd1605a0e.png">
