### PR TITLE
Add multi folderpath support, add --add to each output component, and add a logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Visual Studio] VSConfig Finder
 
-When you want to set up Visual Studio from a new environment, `.vsconfig` files can be very useful as they are easy to be created from your [existing installations](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022) or from a [working solution](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/). However, one existing problem with the `.vsconfig` usage is that Visual Studio Installer supports importing one `.vsconfig` file at a time, so if you have multiple `.vsconfig`s throughout your solution (e.g. you have a monorepo that is consisted of multiple projects) and you want to apply them while setting up your pipeline, you would have to run an installer operation as many times as you'd want to use the different `.vsconfig`s. One way to get around this problem is to generate a single `.vsconfig` yourself that you put on the root of the solution, but this approach still has its own issues: For example, if you're only interested in a subset of the solution, you'll install far more components than the ones you need, resulting in a longer install and subsequent update time.
+When you want to set up Visual Studio from a new environment, `.vsconfig` files can be very useful as they are easy to be created from your [existing installations](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022) or from a [working solution](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/). However, one existing problem with the `.vsconfig` usage is that the Visual Studio Installer supports importing one `.vsconfig` file at a time, so if you have multiple `.vsconfig`s throughout your solution (e.g. you have a monorepo that is consisted of multiple projects) and you want to apply them while setting up your pipeline, you would have to run an installer operation as many times as you'd want to use the different `.vsconfig`s. One way to get around this problem is to generate a single `.vsconfig` yourself that you put on the root of the solution, but this approach still has its own issues: For example, if you're only interested in a subset of the solution, you'll install far more components than the ones you need, resulting in a longer install and subsequent update time.
 
 _VSConfigFinder_ is designed to be a redistributable, single-file executable that can be used in build or deployment scripts to use multiple `.vsconfig`s that exist throughout the solution without having to go through multiple installer operations by recursively finding nested `.vsconfig` files and merging them into a single output file, or an installer command line argument, depending on the customer requirement.
 
@@ -14,6 +14,7 @@ Imagine that you have a solution or a repository with the folder structure as be
 root
   - folderA
   - folderB
+    - .vsconfig (packageE)
   - folderC
     - someProject
       - .vsconfig (packageA, packageB)
@@ -30,9 +31,21 @@ If you want to pass in all the components that are needed to build & run `folder
 
 This will generate the following command as a console output that you can simply pass into the installer.
 
-`--add packageA packageB packageC packageD`
+`--add packageA --add packageB --add packageC --add packageD`
 
 Remember to add your own verb (e.g. `install` or `modify`) in conjunction with the tool output.
+
+## Multi-Root Folders Support
+
+Say if you want to do something similar to the example above, but you want everything under `folderB` AND `folderC`. You cannot pass in one or the other, because the two do not share a common folder (if you pass in the `root`, `folderA` will also be included). Instead, you can simply pass in the topmost folders as a list to achieve your goal.
+
+`VSConfig.exe --folderpath root\folderC root\folderB`
+
+This will generate the following command as a console output that you can simply pass into the installer.
+
+`--add packageA --add packageB --add packageC --add packageD --add packageE`
+
+Again, remember to add your own verb (e.g. `install` or `modify`) in conjunction with the tool output.
 
 ## Alternate Example
 
@@ -41,6 +54,8 @@ Alternatively, you can pass in additional parameters provided by the tool to get
 `VSConfig.exe --folderpath root\folderC --createfile --configoutputpath c:\somefolder`
 
 This will generate an alternate single `.vsconfig` file with all the needed components in the specified `configOutputPath`. If you don't specify a `configOutputPath`, the output directory will default to the current directory.
+
+Note that if you choose to use `--createfile`, the Visual Studio Installer arguments will no longer be output to the console.
 
 ## Contributing
 

--- a/VSConfigFinder.Test/ExtensionsTests.cs
+++ b/VSConfigFinder.Test/ExtensionsTests.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="ExtensionsTests.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace VSConfigFinder.Test
+{
+    using Moq;
+    using Xunit;
+
+    public class ExtensionsTests
+    {
+        [Fact]
+        public void GetFileSystemEntries_MultiplePaths_ReturnSet()
+        {
+            var path1 = "C:\\path1";
+            var subpath1 = Path.Combine(path1, "subpath1", ".vsconfig");
+            var subpath2 = Path.Combine(path1, "subpath2", "something.vsconfig");
+            var path2 = "C:\\path2";
+            var subpath3 = Path.Combine(path2, "subpath3", ".vsconfig");
+            var subpath4 = Path.Combine(path2, "subpath4", "something.vsconfig");
+            var path3 = path2;
+            var subpath5 = subpath3;
+            var subpath6 = subpath4;
+
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem.Setup(x => x.GetFileSystemEntries(path1, "*.vsconfig", true)).Returns(new[] { subpath1, subpath2 });
+            fileSystem.Setup(x => x.GetFileSystemEntries(path2, "*.vsconfig", true)).Returns(new[] { subpath3, subpath4 });
+            fileSystem.Setup(x => x.GetFileSystemEntries(path3, "*.vsconfig", true)).Returns(new[] { subpath5, subpath6 });
+
+            var paths = new[] { path1, path2, path3 };
+
+            var result = Extensions.GetFileSystemEntries(fileSystem.Object, paths, "*.vsconfig", recursive: true);
+
+            Assert.Equal(4, result.Count());
+            Assert.Contains(subpath1, result);
+            Assert.Contains(subpath2, result);
+            Assert.Contains(subpath3, result);
+            Assert.Contains(subpath4, result);
+        }
+    }
+}

--- a/VSConfigFinder/CommandLine/CommandLineOptions.cs
+++ b/VSConfigFinder/CommandLine/CommandLineOptions.cs
@@ -12,7 +12,7 @@ namespace VSConfigFinder
     {
         /// <inheritdoc/>
         [Option("folderpath", Required = true, HelpText = "The source folder path to use as the root. The search will start from the root towards the bottom.")]
-        public string FolderPath { get; set; }
+        public IEnumerable<string> FolderPath { get; set; }
 
         /// <inheritdoc/>
         [Option("createfile", Required = false, Default = false, HelpText = "(Default: false) Bool flag that indicates whether the output gets created as a consolidated .vsconfig file instead of the Visual Studio Installer setup command line arguments.\n" +

--- a/VSConfigFinder/CommandLine/ICommandLineOptions.cs
+++ b/VSConfigFinder/CommandLine/ICommandLineOptions.cs
@@ -11,9 +11,9 @@ namespace VSConfigFinder
     public interface ICommandLineOptions
     {
         /// <summary>
-        /// Gets or sets the folder path to be used as the root (starting point) of the search.
+        /// Gets or sets the folder paths to be used as the root (starting point) of the search.
         /// </summary>
-        string FolderPath { get; set; }
+        IEnumerable<string> FolderPath { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether the output gets created as a consolidated .vsconfig file instead of the Visual Studio Installer setup command line arguments.

--- a/VSConfigFinder/ConsoleLogger.cs
+++ b/VSConfigFinder/ConsoleLogger.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="ConsoleLogger.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace VSConfigFinder
+{
+    using System;
+
+    /// <inheritdoc/>
+    internal class ConsoleLogger : ILogger
+    {
+        /// <inheritdoc/>
+        public void Log(string message) => Console.WriteLine(message);
+    }
+}

--- a/VSConfigFinder/Extensions.cs
+++ b/VSConfigFinder/Extensions.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="Extensions.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace VSConfigFinder
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Extensions class for the tool.
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// The extension method to get entries from multiple paths.
+        /// </summary>
+        /// <param name="fileSystem">The <see cref="IFileSystem"/>.</param>
+        /// <param name="paths">The list of top-level paths.</param>
+        /// <param name="pattern">pattern to match for file names. To match anything and everything, specify '*'</param>
+        /// <param name="recursive">Optional: recursively search sub directories</param>
+        /// <returns></returns>
+        public static IEnumerable<string> GetFileSystemEntries(this IFileSystem fileSystem, IEnumerable<string> paths, string pattern, bool recursive = false)
+        {
+            Utilities.IsNotNull(paths, nameof(paths));
+            Utilities.ValidateIsNotNullOrEmpty(pattern, nameof(pattern));
+
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var path in paths)
+            {
+                result.UnionWith(fileSystem.GetFileSystemEntries(path, pattern, recursive));
+            }
+
+            return result;
+        }
+    }
+}

--- a/VSConfigFinder/FileSystem.cs
+++ b/VSConfigFinder/FileSystem.cs
@@ -11,19 +11,12 @@ namespace VSConfigFinder
     public class FileSystem : IFileSystem
     {
         /// <inheritdoc/>
-        public IEnumerable<string> GetFileSystemEntries(IEnumerable<string> paths, string pattern, bool recursive = false)
+        public IEnumerable<string> GetFileSystemEntries(string path, string pattern, bool recursive = false)
         {
-            Utilities.IsNotNull(paths, nameof(paths));
+            Utilities.ValidateIsNotNullOrEmpty(path, nameof(path));
             Utilities.ValidateIsNotNullOrEmpty(pattern, nameof(pattern));
 
-            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            
-            foreach (var path in paths)
-            {
-                result.UnionWith(Directory.GetFileSystemEntries(path, pattern, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly));
-            }
-
-            return result;
+            return Directory.GetFileSystemEntries(path, pattern, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
         }
 
         /// <inheritdoc/>

--- a/VSConfigFinder/FileSystem.cs
+++ b/VSConfigFinder/FileSystem.cs
@@ -11,12 +11,19 @@ namespace VSConfigFinder
     public class FileSystem : IFileSystem
     {
         /// <inheritdoc/>
-        public string[] GetFileSystemEntries(string path, string pattern, bool recursive = false)
+        public IEnumerable<string> GetFileSystemEntries(IEnumerable<string> paths, string pattern, bool recursive = false)
         {
-            Utilities.ValidateIsNotNullOrEmpty(path, nameof(path));
+            Utilities.IsNotNull(paths, nameof(paths));
             Utilities.ValidateIsNotNullOrEmpty(pattern, nameof(pattern));
 
-            return Directory.GetFileSystemEntries(path, pattern, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            
+            foreach (var path in paths)
+            {
+                result.UnionWith(Directory.GetFileSystemEntries(path, pattern, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly));
+            }
+
+            return result;
         }
 
         /// <inheritdoc/>

--- a/VSConfigFinder/IFileSystem.cs
+++ b/VSConfigFinder/IFileSystem.cs
@@ -13,13 +13,13 @@ namespace VSConfigFinder
         /// <summary>
         /// Get files and directories within directory.
         /// </summary>
-        /// <param name="path">directory path</param>
+        /// <param name="path">directory paths to search for.</param>
         /// <param name="pattern">pattern to match for file names. To match anything and everything, specify '*'</param>
         /// <param name="recursive">Optional: recursively search sub directories</param>
         /// <returns>array of files within the directory</returns>
         /// <exception cref="ArgumentException"><paramref name="path"/> is empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
-        public string[] GetFileSystemEntries(string path, string pattern, bool recursive = false);
+        public IEnumerable<string> GetFileSystemEntries(IEnumerable<string> paths, string pattern, bool recursive = false);
 
         /// <summary>
         /// Opens a file for reading.

--- a/VSConfigFinder/IFileSystem.cs
+++ b/VSConfigFinder/IFileSystem.cs
@@ -13,13 +13,13 @@ namespace VSConfigFinder
         /// <summary>
         /// Get files and directories within directory.
         /// </summary>
-        /// <param name="path">directory paths to search for.</param>
+        /// <param name="path">directory path to search for.</param>
         /// <param name="pattern">pattern to match for file names. To match anything and everything, specify '*'</param>
         /// <param name="recursive">Optional: recursively search sub directories</param>
         /// <returns>array of files within the directory</returns>
         /// <exception cref="ArgumentException"><paramref name="path"/> is empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
-        public IEnumerable<string> GetFileSystemEntries(IEnumerable<string> paths, string pattern, bool recursive = false);
+        public IEnumerable<string> GetFileSystemEntries(string path, string pattern, bool recursive = false);
 
         /// <summary>
         /// Opens a file for reading.

--- a/VSConfigFinder/ILogger.cs
+++ b/VSConfigFinder/ILogger.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="ILogger.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+namespace VSConfigFinder
+{
+    /// <summary>
+    /// The interface to log user messages.
+    /// </summary>
+    public interface ILogger
+    {
+        /// <summary>
+        /// Log the message.
+        /// </summary>
+        /// <param name="message">The message to log.</param>
+        public void Log(string message);
+    }
+}

--- a/VSConfigFinder/Program.cs
+++ b/VSConfigFinder/Program.cs
@@ -32,6 +32,7 @@ namespace VSConfigFinder
         private static void Run(CommandLineOptions options)
         {
             var fileSystem = new FileSystem();
+            var logger = new ConsoleLogger();
 
             ResolveCommandLineOptions(options);
 
@@ -42,7 +43,7 @@ namespace VSConfigFinder
                 Components = Utilities.ReadComponents(fileSystem, options),
             };
 
-            Utilities.CreateOutput(fileSystem, finalConfig, options);
+            Utilities.CreateOutput(fileSystem, logger, finalConfig, options);
         }
 
         private static void ResolveCommandLineOptions(CommandLineOptions options)

--- a/VSConfigFinder/Utilities.cs
+++ b/VSConfigFinder/Utilities.cs
@@ -60,9 +60,10 @@ namespace VSConfigFinder
         /// Create an output from the final <see cref="VSConfig"/> and given <see cref="CommandLineOptions"/>.
         /// </summary>
         /// <param name="fileSystem">The <see cref="IFileSystem"/>.</param>
+        /// <param name="logger">The <see cref="ILogger"/>.</param>
         /// <param name="finalConfig">The final <see cref="VSConfig"/> to export.</param>
         /// <param name="options">The command line options.</param>
-        public static void CreateOutput(IFileSystem fileSystem, VSConfig finalConfig, CommandLineOptions options)
+        public static void CreateOutput(IFileSystem fileSystem, ILogger logger, VSConfig finalConfig, CommandLineOptions options)
         {
             if (options.CreateFile)
             {
@@ -72,13 +73,13 @@ namespace VSConfigFinder
                 var outputPath = Path.Combine(options.ConfigOutputPath!, ConfigExtension);
 
                 fileSystem.WriteAllText(outputPath, jsonString);
-                Console.WriteLine($"Successfully created the final .vsconfig at {outputPath}");
+                logger.Log($"Successfully created the final .vsconfig at {outputPath}");
             }
             else
             {
                 // output to a command line
                 var output = CreateCommandLineOutput(finalConfig);
-                Console.WriteLine(output);
+                logger.Log(output);
             }
         }
 
@@ -118,7 +119,7 @@ namespace VSConfigFinder
 
         private static string CreateCommandLineOutput(VSConfig finalConfig)
         {
-            var output = new StringBuilder(Add + " ");
+            var output = new StringBuilder();
 
             if (finalConfig.Components is not null)
             {
@@ -126,12 +127,12 @@ namespace VSConfigFinder
                 {
                     if (!string.IsNullOrEmpty(component))
                     {
-                        output.AppendFormat("{0} ", component);
+                        output.AppendFormat("{0} {1} ", Add, component);
                     }
                 }
             }
 
-            return output.ToString();
+            return output.ToString().TrimEnd();
         }
     }
 }

--- a/VSConfigFinder/Utilities.cs
+++ b/VSConfigFinder/Utilities.cs
@@ -91,7 +91,7 @@ namespace VSConfigFinder
         /// <returns></returns>
         public static string[] ReadComponents(IFileSystem fileSystem, CommandLineOptions options)
         {
-            var pathsToVsConfigs = fileSystem.GetFileSystemEntries(options.FolderPath, ConfigExtension, recursive: true);
+            var pathsToVsConfigs = fileSystem.GetFileSystemEntries(options.FolderPath, "*" + ConfigExtension, recursive: true);
 
             var componentsSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var serializerOptions = new JsonSerializerOptions


### PR DESCRIPTION
For folder structures like this:

```
a
 - b
   - 1
 - c
   - 2
   - 3
 - d
```

Right now you cannot pass in `b` and `c` at the same time without including `d`. To address this, the change adds a multi folderpath support so we can now use the tool like this:

`VSConfigFinder.exe --folderpath b c`

Also, since the VS Installer doesn't officially support using a single `--add` for all the components, the change also adds `--add` to each output components if `--createFile` option is chosen.

Added a simple logger for testability, and updated the Readme accordingly.

- [x] Verified that the tool with `CreateFile == true` works and outputs the file as expected. Overwrites the existing one if exists.
- [x] Verified that the tool with `CreateFile == false` works and outputs the arguments as expected.
- [x] Verified that the single and multi folders all get parsed correctly as expected.
- [x] Verified that both the unnamed vsconfig (e.g. `.vsconfig`) and named vsconfig (e.g. `something.vsconfig`) both get picked up and read correctly