### PR TITLE
Add support for publishing a single file executable

### DIFF
--- a/.github/workflows/actions-pr.yml
+++ b/.github/workflows/actions-pr.yml
@@ -38,3 +38,6 @@ jobs:
     
     - name: Test
       run: dotnet test --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} ${{ env.TEST_PROJECT_PATH }}
+
+    - name: Publish
+      run: dotnet publish --no-build --configuration ${{ env.BUILD_CONFIGURATION }} ${{ env.TEST_PROJECT_PATH }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,22 +6,4 @@
       <Version>3.5.119</Version>
     </PackageReference>
   </ItemGroup>
-
-  <Target Name="SignPublishFiles"
-          Condition=" '$(MicroBuild_SigningEnabled)' == 'true' "
-          AfterTargets="Publish">
-	<ItemGroup>
-      <FilesToSign Include="$(PublishDir)$(TargetName)$(TargetExt)">
-        <PublishOnly>true</PublishOnly>
-      </FilesToSign>
-    </ItemGroup>
-    <SignFiles Files="@(FilesToSign)"
-               Type="$(SignType)"
-               BinariesDirectory="$(OutDir)"
-               IntermediatesDirectory="$(IntermediateOutputPath)"
-               Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
-    <ItemGroup>
-      <FilesToSign Remove="@(FilesToSign)" Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,4 +6,22 @@
       <Version>3.5.119</Version>
     </PackageReference>
   </ItemGroup>
+
+  <Target Name="SignPublishFiles"
+          Condition=" '$(MicroBuild_SigningEnabled)' == 'true' "
+          AfterTargets="Publish">
+	<ItemGroup>
+      <FilesToSign Include="$(PublishDir)$(TargetName)$(TargetExt)">
+        <PublishOnly>true</PublishOnly>
+      </FilesToSign>
+    </ItemGroup>
+    <SignFiles Files="@(FilesToSign)"
+               Type="$(SignType)"
+               BinariesDirectory="$(OutDir)"
+               IntermediatesDirectory="$(IntermediateOutputPath)"
+               Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
+    <ItemGroup>
+      <FilesToSign Remove="@(FilesToSign)" Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -7,10 +7,26 @@
     <Nullable>enable</Nullable>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishPath>$(OutputPath)$(RuntimeIdentifier)\publish\</PublishPath>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+    
+  <ItemGroup>
+    <FilesToSign Include="$(PublishPath)VSConfigFinder.dll">
+        <Authenticode>Microsoft400</Authenticode>
+        <StrongName>StrongName</StrongName>
+    </FilesToSign>
+    <FilesToSign Include="$(PublishPath)VSConfigFinder.exe" Condition=" Exists('$(PublishPath)VSConfigFinder.exe') ">
+        <Authenticode>Microsoft400</Authenticode>
+    </FilesToSign>
   </ItemGroup>
 
   <ItemGroup>

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -18,16 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-    
-  <ItemGroup>
-    <FilesToSign Include="$(PublishPath)VSConfigFinder.dll">
-        <Authenticode>Microsoft400</Authenticode>
-        <StrongName>StrongName</StrongName>
-    </FilesToSign>
-    <FilesToSign Include="$(PublishPath)VSConfigFinder.exe" Condition=" Exists('$(PublishPath)VSConfigFinder.exe') ">
-        <Authenticode>Microsoft400</Authenticode>
-    </FilesToSign>
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -1,10 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -3,6 +3,8 @@
 
 variables:
   BuildConfiguration: Release
+  SignType: test
+  TeamName: vssetup
 
 trigger:
   batch: true
@@ -22,6 +24,13 @@ queue:
 steps:
 - checkout: self
   fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
+
+- task: MicroBuildSigningPlugin@4
+  inputs:
+    signType: '$(SignType)'
+    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+  env:
+    TeamName: '$(TeamName)'
 
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -42,6 +42,12 @@ steps:
     projects: 'VSConfigFinder.Test'
     arguments: '--configuration $(BuildConfiguration)'
 
+- task: DotNetCoreCLI@2
+  displayName: Publish
+  inputs:
+    command: 'publish'
+    arguments: '--no-build --configuration $(BuildConfiguration)'
+
 - task: CopyFiles@2
   displayName: 'Copy build artifacts from: $(Build.SourcesDirectory)\VSConfigFinder\bin\$(BuildConfiguration)\** to $(Build.ArtifactStagingDirectory)\out'
   inputs:

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -3,8 +3,6 @@
 
 variables:
   BuildConfiguration: Release
-  SignType: test
-  TeamName: vssetup
 
 trigger:
   batch: true
@@ -24,13 +22,6 @@ queue:
 steps:
 - checkout: self
   fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
-
-- task: MicroBuildSigningPlugin@4
-  inputs:
-    signType: '$(SignType)'
-    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-  env:
-    TeamName: '$(TeamName)'
 
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'


### PR DESCRIPTION
We need to make sure to publish a single file executable for signing.