### PR TITLE
Sign files appropriate before and after publish

### DIFF
--- a/.github/workflows/actions-pr.yml
+++ b/.github/workflows/actions-pr.yml
@@ -40,4 +40,4 @@ jobs:
       run: dotnet test --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} ${{ env.TEST_PROJECT_PATH }}
 
     - name: Publish
-      run: dotnet publish --no-build --configuration ${{ env.BUILD_CONFIGURATION }} ${{ env.TEST_PROJECT_PATH }}
+      run: dotnet publish --no-build --configuration ${{ env.BUILD_CONFIGURATION }} ${{ env.PROJECT_PATH }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,4 +6,22 @@
       <Version>3.5.119</Version>
     </PackageReference>
   </ItemGroup>
+	
+  <Target Name="SignPublishFiles"
+          Condition=" '$(MicroBuild_SigningEnabled)' == 'true' "
+          AfterTargets="Publish">
+    <ItemGroup>
+      <FilesToSign Include="$(PublishDir)$(TargetName)$(TargetExt)">
+        <PublishOnly>true</PublishOnly>
+      </FilesToSign>
+    </ItemGroup>
+	<SignFiles Files="@(FilesToSign)"
+               Type="$(SignType)"
+               BinariesDirectory="$(OutDir)"
+               IntermediatesDirectory="$(IntermediateOutputPath)"
+               Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
+	<ItemGroup>
+      <FilesToSign Remove="@(FilesToSign)" Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
+	</ItemGroup>
+  </Target>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,22 +6,4 @@
       <Version>3.5.119</Version>
     </PackageReference>
   </ItemGroup>
-	
-  <Target Name="SignPublishFiles"
-          Condition=" '$(MicroBuild_SigningEnabled)' == 'true' "
-          AfterTargets="Publish">
-    <ItemGroup>
-      <FilesToSign Include="$(PublishDir)$(TargetName)$(TargetExt)">
-        <PublishOnly>true</PublishOnly>
-      </FilesToSign>
-    </ItemGroup>
-	<SignFiles Files="@(FilesToSign)"
-               Type="$(SignType)"
-               BinariesDirectory="$(OutDir)"
-               IntermediatesDirectory="$(IntermediateOutputPath)"
-               Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
-	<ItemGroup>
-      <FilesToSign Remove="@(FilesToSign)" Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
-	</ItemGroup>
-  </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="SignPublishFiles"
+			Condition=" '$(MicroBuild_SigningEnabled)' == 'true' "
+			AfterTargets="Publish">
+		<ItemGroup>
+			<FilesToSign Include="$(PublishDir)$(TargetName)$(TargetExt)">
+				<PublishOnly>true</PublishOnly>
+				<Authenticode>Microsoft400</Authenticode>
+			</FilesToSign>
+		</ItemGroup>
+		<SignFiles Files="@(FilesToSign)"
+				   Type="$(SignType)"
+				   BinariesDirectory="$(OutDir)"
+				   IntermediatesDirectory="$(IntermediateOutputPath)"
+				   Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
+		<ItemGroup>
+			<FilesToSign Remove="@(FilesToSign)" Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="SignThirdPartyFiles" BeforeTargets="PackBuildOutputs" DependsOnTargets="Publish">
+		<SignFiles Files="@(PublishThirdPartyFilesToSign)" Type="$(SignType)" BinariesDirectory="$(PublishDir)" IntermediatesDirectory="$(IntermediateOutputPath)" ESRPSigning="" UseBearerToken="" Condition=" '@(PublishThirdPartyFilesToSign)' != '' " />
+	</Target>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,8 +18,4 @@
 			<FilesToSign Remove="@(FilesToSign)" Condition=" '%(FilesToSign.PublishOnly)' == 'true' " />
 		</ItemGroup>
 	</Target>
-
-	<Target Name="SignThirdPartyFiles" BeforeTargets="PackBuildOutputs" DependsOnTargets="Publish">
-		<SignFiles Files="@(PublishThirdPartyFilesToSign)" Type="$(SignType)" BinariesDirectory="$(PublishDir)" IntermediatesDirectory="$(IntermediateOutputPath)" ESRPSigning="" UseBearerToken="" Condition=" '@(PublishThirdPartyFilesToSign)' != '' " />
-	</Target>
 </Project>

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -32,11 +32,11 @@
   </ItemGroup>
     
     <ItemGroup>
-        <EditorConfigFiles Remove="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />
+        <EditorConfigFiles Remove=".editorconfig" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />
+        <None Include=".editorconfig" />
     </ItemGroup>
 
 </Project>

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -8,7 +8,6 @@
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <PublishTrimmed>true</PublishTrimmed>
-        <PublishPath>$(OutputPath)$(RuntimeIdentifier)\publish\</PublishPath>
 	</PropertyGroup>
 	
 	<ItemGroup>
@@ -20,15 +19,15 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-        <FilesToSign Include="$(PublishPath)VSConfigFinder.dll">
+        <FilesToSign Include="$(OutputPath)VSConfigFinder.dll">
 			<Authenticode>Microsoft400</Authenticode>
         </FilesToSign>
-        <FilesToSign Include="$(PublishPath)VSConfigFinder.exe" Condition=" Exists('$(PublishPath)VSConfigFinder.exe') ">
+        <FilesToSign Include="$(OutputPath)VSConfigFinder.exe" Condition=" Exists('$(OutputPath)VSConfigFinder.exe') ">
 			<Authenticode>Microsoft400</Authenticode>
         </FilesToSign>
-		<PublishThirdPartyFilesToSign Include="$(PublishPath)\CommandLine.dll" >
+        <FilesToSign Include="$(OutputPath)CommandLine.dll">
 			<Authenticode>3PartySHA2</Authenticode>
-		</PublishThirdPartyFilesToSign>
+		</FilesToSign>
   </ItemGroup>
     
     <ItemGroup>

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -20,6 +20,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FilesToSign Include="$(PublishPath)VSConfigFinder.dll">
+      <Authenticode>Microsoft400</Authenticode>
+      <StrongName>StrongName</StrongName>
+    </FilesToSign>
+    <FilesToSign Include="$(PublishPath)VSConfigFinder.exe" Condition=" Exists('$(PublishPath)VSConfigFinder.exe') ">
+      <Authenticode>Microsoft400</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
+    
+  <ItemGroup>
     <EditorConfigFiles Remove="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />
   </ItemGroup>
 

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -1,39 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
-    <PublishTrimmed>true</PublishTrimmed>
-    <PublishPath>$(OutputPath)$(RuntimeIdentifier)\publish\</PublishPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <FilesToSign Include="$(PublishPath)VSConfigFinder.dll">
-      <Authenticode>Microsoft400</Authenticode>
-    </FilesToSign>
-    <FilesToSign Include="$(PublishPath)VSConfigFinder.exe" Condition=" Exists('$(PublishPath)VSConfigFinder.exe') ">
-      <Authenticode>Microsoft400</Authenticode>
-    </FilesToSign>
+	
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PublishSingleFile>true</PublishSingleFile>
+        <SelfContained>true</SelfContained>
+        <PublishTrimmed>true</PublishTrimmed>
+        <PublishPath>$(OutputPath)$(RuntimeIdentifier)\publish\</PublishPath>
+	</PropertyGroup>
+	
+	<ItemGroup>
+        <PackageReference Include="CommandLineParser" Version="2.9.1" />
+        <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+	</ItemGroup>
+	
+	<ItemGroup>
+        <FilesToSign Include="$(PublishPath)VSConfigFinder.dll">
+			<Authenticode>Microsoft400</Authenticode>
+        </FilesToSign>
+        <FilesToSign Include="$(PublishPath)VSConfigFinder.exe" Condition=" Exists('$(PublishPath)VSConfigFinder.exe') ">
+			<Authenticode>Microsoft400</Authenticode>
+        </FilesToSign>
+		<PublishThirdPartyFilesToSign Include="$(PublishPath)\CommandLine.dll" >
+			<Authenticode>3PartySHA2</Authenticode>
+		</PublishThirdPartyFilesToSign>
   </ItemGroup>
     
-  <ItemGroup>
-    <EditorConfigFiles Remove="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />
-  </ItemGroup>
+    <ItemGroup>
+        <EditorConfigFiles Remove="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="C:\Users\sknam\source\repos\VSConfigFinder\VSConfigFinder\.editorconfig" />
+    </ItemGroup>
 
 </Project>

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <FilesToSign Include="$(PublishPath)VSConfigFinder.dll">
       <Authenticode>Microsoft400</Authenticode>
-      <StrongName>StrongName</StrongName>
     </FilesToSign>
     <FilesToSign Include="$(PublishPath)VSConfigFinder.exe" Condition=" Exists('$(PublishPath)VSConfigFinder.exe') ">
       <Authenticode>Microsoft400</Authenticode>

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -3,6 +3,8 @@
 
 variables:
   BuildConfiguration: Release
+  SignType: test
+  TeamName: vssetup
 
 trigger:
   batch: true
@@ -22,6 +24,13 @@ queue:
 steps:
 - checkout: self
   fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
+
+- task: MicroBuildSigningPlugin@4
+  inputs:
+    signType: '$(SignType)'
+    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+  env:
+    TeamName: '$(TeamName)'
 
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'


### PR DESCRIPTION
Update directory.build.props, csproj, and the CI pipeline in order to sign files before and after publishing.