### PR TITLE
Make sure to specify in the publish step that the project is not a web project

### DIFF
--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -41,6 +41,7 @@ steps:
     command: 'test'
     projects: 'VSConfigFinder.Test'
     arguments: '--configuration $(BuildConfiguration)'
+    publishWebProjects: false
 
 - task: DotNetCoreCLI@2
   displayName: Publish

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -41,13 +41,13 @@ steps:
     command: 'test'
     projects: 'VSConfigFinder.Test'
     arguments: '--configuration $(BuildConfiguration)'
-    publishWebProjects: false
 
 - task: DotNetCoreCLI@2
   displayName: Publish
   inputs:
     command: 'publish'
     arguments: '--no-build --configuration $(BuildConfiguration)'
+    publishWebProjects: false
 
 - task: CopyFiles@2
   displayName: 'Copy build artifacts from: $(Build.SourcesDirectory)\VSConfigFinder\bin\$(BuildConfiguration)\** to $(Build.ArtifactStagingDirectory)\out'


### PR DESCRIPTION

The CI build step is currently failing because `publishWebProjects` is by default `true`, but since we're not publishing a web project, we should set it to false.