### PR TITLE
Update targetext in Directory.Build.targets to .exe from .dll

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,7 +4,7 @@
 			Condition=" '$(MicroBuild_SigningEnabled)' == 'true' "
 			AfterTargets="Publish">
 		<ItemGroup>
-			<FilesToSign Include="$(PublishDir)$(TargetName)$(TargetExt)">
+			<FilesToSign Include="$(PublishDir)$(TargetName).exe">
 				<PublishOnly>true</PublishOnly>
 				<Authenticode>Microsoft400</Authenticode>
 			</FilesToSign>


### PR DESCRIPTION
Update targetext in Directory.Build.targets to .exe from .dll to sign after publish appropriately.