### PR TITLE
Change to real-signed for CI

### DIFF
--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -3,7 +3,7 @@
 
 variables:
   BuildConfiguration: Release
-  SignType: test
+  SignType: real
   TeamName: vssetup
 
 trigger:


### PR DESCRIPTION
Now that we have the pipeline approved for running real-signed builds, we should start real signing files.