### PR TITLE
Fix nbgv versioning

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -5,12 +5,6 @@ parameters:
   BuildConfiguration: Release
 
 steps:
-- powershell: |
-    dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv
-    $version = & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" get-version --variable SemVer1
-    & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" cloud --version $version
-  displayName: 'Set cloud build version'
-
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
@@ -39,7 +33,7 @@ steps:
     zipAfterPublish: false
 
 - script: |
-    choco pack pkg\VSConfigFinder\VSConfigFinder.nuspec --out "VSConfigFinder\bin\${{ parameters.BuildConfiguration }}" --version "%NBGV_NuGetPackageVersion%" "Configuration=${{ parameters.BuildConfiguration }}" "CommitId=$(Build.SourceVersion)" "Tag=$(Build.BuildNumber)"
+    choco pack pkg\VSConfigFinder\VSConfigFinder.nuspec --out "VSConfigFinder\bin\${{ parameters.BuildConfiguration }}" --version "$(Build.GitBuildVersion)" "Configuration=${{ parameters.BuildConfiguration }}" "CommitId=$(Build.SourceVersion)" "Tag=$(Build.BuildNumber)"
   displayName: Package
   workingDirectory: $(Build.SourcesDirectory)
 

--- a/build.yml
+++ b/build.yml
@@ -34,11 +34,11 @@ steps:
 
 - script: |
     choco pack pkg\VSConfigFinder\VSConfigFinder.nuspec --out "VSConfigFinder\bin\${{ parameters.BuildConfiguration }}" --version "$(GitBuildVersion)" "Configuration=${{ parameters.BuildConfiguration }}" "CommitId=$(Build.SourceVersion)" "Tag=$(Build.BuildNumber)"
-  displayName: Package
+  displayName: 'Package Nupkg'
   workingDirectory: $(Build.SourcesDirectory)
 
 - task: CopyFiles@2
-  displayName: 'Copy build artifacts from: $(Build.SourcesDirectory)\VSConfigFinder\bin\$(BuildConfiguration)\** to $(Build.ArtifactStagingDirectory)\out'
+  displayName: 'Copy build artifacts'
   inputs:
     SourceFolder: $(Build.SourcesDirectory)\VSConfigFinder
     Contents: |
@@ -46,7 +46,7 @@ steps:
     TargetFolder: $(Build.ArtifactStagingDirectory)\out
 
 - task: PublishBuildArtifacts@1
-  displayName: 'Publish build artifacts from: $(Build.ArtifactStagingDirectory)\out'
+  displayName: 'Publish build artifacts'
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)\out
     ArtifactName: drop

--- a/build.yml
+++ b/build.yml
@@ -5,6 +5,12 @@ parameters:
   BuildConfiguration: Release
 
 steps:
+- powershell: |
+    dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv
+    $version = & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" get-version --variable SemVer1
+    & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" cloud --version $version
+  displayName: 'Set cloud build version'
+
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:

--- a/build.yml
+++ b/build.yml
@@ -33,7 +33,7 @@ steps:
     zipAfterPublish: false
 
 - script: |
-    choco pack pkg\VSConfigFinder\VSConfigFinder.nuspec --out "VSConfigFinder\bin\${{ parameters.BuildConfiguration }}" --version "$(Build.GitBuildVersion)" "Configuration=${{ parameters.BuildConfiguration }}" "CommitId=$(Build.SourceVersion)" "Tag=$(Build.BuildNumber)"
+    choco pack pkg\VSConfigFinder\VSConfigFinder.nuspec --out "VSConfigFinder\bin\${{ parameters.BuildConfiguration }}" --version "$(GitBuildVersion)" "Configuration=${{ parameters.BuildConfiguration }}" "CommitId=$(Build.SourceVersion)" "Tag=$(Build.BuildNumber)"
   displayName: Package
   workingDirectory: $(Build.SourcesDirectory)
 


### PR DESCRIPTION
%NBGV_NuGetPackageVersion% doesn't work for us. We need to supply the $(GitBuildVersion) that is recommended by https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/cloudbuild.md.

Testing:
![image](https://user-images.githubusercontent.com/25760992/221721337-eb49ca8f-2107-4598-8774-fda4b1cc3341.png)
