### PR TITLE
Update CredScan version

### DIFF
--- a/vsts-compliance.yml
+++ b/vsts-compliance.yml
@@ -108,6 +108,7 @@ steps:
 - task: CredScan@2
   displayName: 'Run CredScan'
   inputs:
+    toolMajorVersion: V2
     debugMode: false
 
 - task: PublishSecurityAnalysisLogs@2


### PR DESCRIPTION
## What?
Updating CredScan Version to 2 since deprecation is coming in months

## Why?
Avoid deprecation

## How?
Add toolMajorVersion

## Testing?
Ran pipeline, no more warning about CredScan version: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7591109&view=results
