### PR TITLE
Updated the actions-pr.yml to run on pull_request instead of push

### DIFF
--- a/.github/workflows/actions-pr.yml
+++ b/.github/workflows/actions-pr.yml
@@ -3,7 +3,7 @@
 
 name: PR Build
 
-on: [ push ]
+on: [ pull_request ]
 
 env:
   # Path to the project source.


### PR DESCRIPTION
## What?
Updated the actions-pr.yml to run on pull_request instead of push

## Why?
So that we can let the forked repositories run the build as well.

## How?
Updated the actions-pr.yml to run on pull_request instead of push

## Testing?
- [x] N/A