### PR TITLE
Update pipelines to MicroBuild template

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -5,49 +5,48 @@ parameters:
   BuildConfiguration: Release
 
 steps:
-- task: UseDotNet@2
-  displayName: 'Install .NET Core SDK'
-  inputs:
-    useGlobalJson: true
-    
-- task: DotNetCoreCLI@2
-  displayName: Build
-  inputs:
-    command: 'build'
-    projects: 'VSConfigFinder'
-    arguments: '--configuration $(BuildConfiguration)'
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core SDK'
+    inputs:
+      useGlobalJson: true
+      
+  - task: DotNetCoreCLI@2
+    displayName: Build
+    inputs:
+      command: 'build'
+      projects: 'VSConfigFinder'
+      arguments: '--configuration $(BuildConfiguration)'
 
-- task: DotNetCoreCLI@2
-  displayName: Test
-  inputs:
-    command: 'test'
-    projects: 'VSConfigFinder.Test'
-    arguments: '--configuration $(BuildConfiguration)'
+  - task: DotNetCoreCLI@2
+    displayName: Test
+    inputs:
+      command: 'test'
+      projects: 'VSConfigFinder.Test'
+      arguments: '--configuration $(BuildConfiguration)'
 
-- task: DotNetCoreCLI@2
-  displayName: Publish
-  inputs:
-    command: 'publish'
-    arguments: '--no-build --configuration $(BuildConfiguration)'
-    publishWebProjects: false
-    zipAfterPublish: false
+  - task: DotNetCoreCLI@2
+    displayName: Publish
+    inputs:
+      command: 'publish'
+      arguments: '--no-build --configuration $(BuildConfiguration)'
+      publishWebProjects: false
+      zipAfterPublish: false
 
-- script: |
-    choco pack pkg\VSConfigFinder\VSConfigFinder.nuspec --out "VSConfigFinder\bin\${{ parameters.BuildConfiguration }}" --version "$(GitBuildVersion)" "Configuration=${{ parameters.BuildConfiguration }}" "CommitId=$(Build.SourceVersion)" "Tag=$(Build.BuildNumber)"
-  displayName: 'Package Nupkg'
-  workingDirectory: $(Build.SourcesDirectory)
+  - script: |
+      choco pack pkg\VSConfigFinder\VSConfigFinder.nuspec --out "VSConfigFinder\bin\${{ parameters.BuildConfiguration }}" --version "$(GitBuildVersion)" "Configuration=${{ parameters.BuildConfiguration }}" "CommitId=$(Build.SourceVersion)" "Tag=$(Build.BuildNumber)"
+    displayName: 'Package Nupkg'
+    workingDirectory: $(Build.SourcesDirectory)
 
-- task: CopyFiles@2
-  displayName: 'Copy build artifacts'
-  inputs:
-    SourceFolder: $(Build.SourcesDirectory)\VSConfigFinder
-    Contents: |
-     bin\$(BuildConfiguration)\**
-    TargetFolder: $(Build.ArtifactStagingDirectory)\out
+  - task: CopyFiles@2
+    displayName: 'Copy build artifacts'
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)\VSConfigFinder
+      Contents: |
+        bin\$(BuildConfiguration)\**
+      TargetFolder: $(Build.ArtifactStagingDirectory)\out
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish build artifacts'
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)\out
-    ArtifactName: drop
-    publishLocation: Container
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: 'Publish build artifacts'
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)\out
+      artifactName: drop

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -17,25 +17,42 @@ trigger:
 
 pr: none
 
-queue:
-  name: VSEngSS-MicroBuild2019-1ES
-  timeoutInMinutes: 120
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
-steps:
-- checkout: self
-  fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
-
-- task: MicroBuildSigningPlugin@4
-  inputs:
-    signType: '$(SignType)'
-    feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-  env:
-    TeamName: '$(TeamName)'
-
-- template: build.yml
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-      BuildConfiguration: $(BuildConfiguration)
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: AzurePipelinesWindows2022compliantGPT
+      policheck:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true # BinSkim scans whole source tree but we only need to scan the output dir.
 
-- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-  displayName: Clean up
-  condition: succeededOrFailed()
+    stages:
+      - stage: Build
+        jobs:
+          - job: Build
+            templateContext:
+              mb:
+                signing:
+                  enabled: true
+                  signType: $(SignType)
+
+            steps:
+              - checkout: self
+                fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
+
+              - template: /build.yml@self
+                parameters:
+                  BuildConfiguration: $(BuildConfiguration)

--- a/vsts-compliance.yml
+++ b/vsts-compliance.yml
@@ -1,24 +1,6 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
-parameters:
-  - name: BinSkimAllowList
-    type: object
-    default: 
-      - clrgc.dll
-      - clrjit.dll
-      - coreclr.dll
-      - createdump.dll
-      - createdump.exe
-      - hostfxr.dll
-      - hostpolicy.dll
-      - Microsoft.DiaSymReader.Native.amd64.dll
-      - mscordaccore.dll
-      - mscordaccore_amd64_amd64_7.0.323.6910.dll
-      - mscordbi.dll;
-      - msquic.dll;
-      - System.IO.Compression.Native.dll
-
 variables:
   BuildConfiguration: Release
   TeamName: vssetup
@@ -34,10 +16,6 @@ trigger:
 
 pr: none
 
-queue:
-  name: VSEngSS-MicroBuild2022-1ES
-  timeoutInMinutes: 120
-
 schedules:
 - cron: "0 12 * * 1"
   displayName: 'Run every Monday at 12:00 p.m.'
@@ -46,79 +24,32 @@ schedules:
     - main
   always: true
 
-steps:
-- template: build.yml
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-      BuildConfiguration: $(BuildConfiguration)
-
-- powershell: |
-    $glob = "$(Build.ArtifactStagingDirectory)/**/*.dll;$(Build.ArtifactStagingDirectory)/**/*.exe;"
-    $array = $env:BinSkimAllowList | ConvertFrom-Json
-    $array | ForEach-Object {
-      $file = $_
-      $glob += "-:f|$(Build.ArtifactStagingDirectory)/**/${file};"
-    }
-
-    Write-Host "##vso[task.setvariable variable=BinSkimGlob;]$glob"
-    Write-Host "BinSkim glob: $glob"
-  displayName: Set BinSkim scanning glob
-  env:
-    BinSkimAllowList: ${{ convertToJson(parameters.BinSkimAllowList) }}
-
-- task: BinSkim@4
-  displayName: 'Run BinSkim'
-  inputs:
-    InputType: Basic
-    Function: analyze
-    TargetPattern: guardianGlob
-    AnalyzeTargetGlob: $(BinSkimGlob)
-    AnalyzeSymPath: 'Srv*http://msdl.microsoft.com/download/symbols'
-    AnalyzeLocalSymbolDirectories: $(Build.ArtifactStagingDirectory)
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-  continueOnError: true
-
-- task: ComponentGovernanceComponentDetection@0
-  displayName: 'Run Component Detection'
-  inputs:
-    sourceScanPath: $(Build.SourcesDirectory)
-  continueOnError: True
-
-- task: RoslynAnalyzers@3
-  displayName: 'Run Roslyn Analyzers'
-  inputs:
-    userProvideBuildInfo: auto
-    rulesetName: Recommended
-    rulesetVersion: Latest
-  condition: succeededOrFailed()
-  continueOnError: True
-  env:
-    system_accesstoken: $(System.AccessToken)
-
-- task: PoliCheck@2
-  displayName: 'Run PoliCheck'
-  inputs:
-    targetType: F
-    targetArgument: '$(Build.SourcesDirectory)'
-    optionsFC: 0
-    optionsXS: 1
-    optionsHMENABLE: 0
-  continueOnError: true
-
-- task: CredScan@2
-  displayName: 'Run CredScan'
-  inputs:
-    toolMajorVersion: V2
-    debugMode: false
-
-- task: PublishSecurityAnalysisLogs@2
-  displayName: 'Publish Security Analysis Logs'
-
-- task: PostAnalysis@1
-  displayName: 'Check SDL results'
-  inputs:
-    AllTools: true
-
-- task: MicroBuildCleanup@1
-  displayName: 'Clean up'
-  condition: succeededOrFailed()
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: AzurePipelinesWindows2022compliantGPT
+      policheck:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true # BinSkim scans whole source tree but we only need to scan the output dir.
+    stages:
+      - stage: Compliance
+        jobs:
+          - job: Compliance
+            steps:
+              - template: /build.yml@self
+                parameters:
+                  BuildConfiguration: $(BuildConfiguration)


### PR DESCRIPTION
## What?
Update pipelines to MicroBuild template

## Why?
To be compliant, we are required to move to the 1ES pipeline template for all production builds. The MicroBuild template is an extension on that and simplifies installing MicroBuild plugins, so we moved there instead.

## How?
- Update the CI and compliance builds to use the MicroBuild template
- 
## Testing?
- [X] Verified compliance build passes
- [X] Verified CI build passes