### PR TITLE
Update Microsoft.NET.Test.Sdk to the latest stable 17.10.0

### DIFF
--- a/VSConfigFinder.Test/VSConfigFinder.Test.csproj
+++ b/VSConfigFinder.Test/VSConfigFinder.Test.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
## What?
Update Microsoft.NET.Test.Sdk to the latest stable 17.10.0

## Why?
We have a security vulnerability for the older 9.0.1 Newtonsoft.Json version that is used by the current Microsoft.NET.Test.Sdk version.

## How?
Bump up the version to the latest so that we use the Newtonsoft.Json version equal to or higher than 13.0.1.

## Testing?
- [x] Ran the component governance tool using Wave Analysis and ensured the scan passes