### PR TITLE
Enable PME signing for VSConfigFinder

### DIFF
--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -52,6 +52,7 @@ extends:
                 signing:
                   enabled: true
                   signType: $(SignType)
+                  signWithProd: true
 
             steps:
               - checkout: self


### PR DESCRIPTION
## What/Why
We need to enable PME signing with the new rule enforcement (Real signing with PME Enforcement - June 30th 2025).

## How
Enable PME signing with `signWithProd: true`

## Testing
Verified the stages can be configured in the topic branch (which indicates no errors in the pipeline).