### PR TITLE
Upgrade from .NET 7.0 (EOL) to .NET 10.0 (LTS)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/VSConfigFinder.Test/VSConfigFinder.Test.csproj
+++ b/VSConfigFinder.Test/VSConfigFinder.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/VSConfigFinder.Test/VSConfigFinder.Test.csproj
+++ b/VSConfigFinder.Test/VSConfigFinder.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -2,7 +2,7 @@
 	
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>

--- a/VSConfigFinder/VSConfigFinder.csproj
+++ b/VSConfigFinder/VSConfigFinder.csproj
@@ -2,7 +2,7 @@
 	
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.200",
+    "version": "8.0.200",
     "rollForward": "feature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "10.0.103",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
## What?
Upgrade VSConfigFinder from .NET 7.0 to .NET 10.0 (LTS) and add Dependabot configuration for automated dependency updates.

## Why?
.NET 7.0 has reached end-of-life, triggering S360 compliance action item AB#2769425 under the [SFI-ES5.2] 1ES Open Source Vulnerabilities KPI (High risk, due 5/27/2026). .NET 10.0 is the latest Long-Term Support release, supported through November 2028 — skipping .NET 8 (which EOLs November 2026) to avoid another upgrade in 8 months.

## How?
- global.json: SDK version 7.0.200 → 10.0.103 (rollForward: feature)
- VSConfigFinder.csproj: TargetFramework net7.0 → net10.0
- VSConfigFinder.Test.csproj: TargetFramework net7.0 → net10.0
- Added .github/dependabot.yml: Configures monthly Dependabot updates for NuGet packages and GitHub Actions versions to prevent future EOL drift (aligned with team convention from VSUpdater)

No API or behavioral changes — CI pipelines read from global.json so no YAML changes are needed.

## Testing?
- [x] dotnet build succeeds (0 errors, 1 pre-existing nullable warning)
- [x] dotnet test passes all 6 tests
- [x] No functional changes; framework upgrade only