### PR TITLE
Add checked-in nuget.config to prevent nuget.org access during build

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -15,9 +15,8 @@ steps:
     inputs:
       command: 'restore'
       projects: 'VSConfigFinder'
-      feedsToUse: 'select'
-      vstsFeed: 'Setup-Dependencies'
-      includeNuGetOrg: false
+      feedsToUse: 'config'
+      nugetConfigPath: 'nuget.config'
       
   - task: DotNetCoreCLI@2
     displayName: Build
@@ -31,9 +30,8 @@ steps:
     inputs:
       command: 'restore'
       projects: 'VSConfigFinder.Test'
-      feedsToUse: 'select'
-      vstsFeed: 'Setup-Dependencies'
-      includeNuGetOrg: false
+      feedsToUse: 'config'
+      nugetConfigPath: 'nuget.config'
 
   - task: DotNetCoreCLI@2
     displayName: Test

--- a/build.yml
+++ b/build.yml
@@ -10,6 +10,9 @@ steps:
     inputs:
       useGlobalJson: true
       
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate to Azure Artifacts
+  
   - task: DotNetCoreCLI@2
     displayName: Restore Build
     inputs:

--- a/build.yml
+++ b/build.yml
@@ -16,7 +16,7 @@ steps:
       command: 'restore'
       projects: 'VSConfigFinder'
       feedsToUse: 'config'
-      nugetConfigPath: 'nuget.config'
+      nugetConfigPath: '$(Build.SourcesDirectory)\nuget.config'
       
   - task: DotNetCoreCLI@2
     displayName: Build
@@ -31,7 +31,7 @@ steps:
       command: 'restore'
       projects: 'VSConfigFinder.Test'
       feedsToUse: 'config'
-      nugetConfigPath: 'nuget.config'
+      nugetConfigPath: '$(Build.SourcesDirectory)\nuget.config'
 
   - task: DotNetCoreCLI@2
     displayName: Test

--- a/build.yml
+++ b/build.yml
@@ -38,7 +38,7 @@ steps:
     inputs:
       command: 'test'
       projects: 'VSConfigFinder.Test'
-      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build -p:RestoreConfigFile=$(Build.SourcesDirectory)/nuget.config'
+      arguments: '--configuration $(BuildConfiguration) --no-restore -p:RestoreConfigFile=$(Build.SourcesDirectory)/nuget.config'
 
   - task: DotNetCoreCLI@2
     displayName: Publish

--- a/build.yml
+++ b/build.yml
@@ -38,7 +38,7 @@ steps:
     inputs:
       command: 'test'
       projects: 'VSConfigFinder.Test'
-      arguments: '--configuration $(BuildConfiguration) --no-restore'
+      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build -p:RestoreConfigFile=$(Build.SourcesDirectory)/nuget.config'
 
   - task: DotNetCoreCLI@2
     displayName: Publish

--- a/build.yml
+++ b/build.yml
@@ -23,7 +23,7 @@ steps:
     inputs:
       command: 'build'
       projects: 'VSConfigFinder'
-      arguments: '--configuration $(BuildConfiguration) --no-restore'
+      arguments: '--configuration $(BuildConfiguration) --no-restore --configfile $(Build.SourcesDirectory)/nuget.config'
 
   - task: DotNetCoreCLI@2
     displayName: Restore Test

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Setup-Dependencies" value="https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Add Nuget.config file for DotNetCLI tasks to use for accessing nuget feed.